### PR TITLE
Fix uniqueness0 issue and MLP dropout issue

### DIFF
--- a/synthetic/get_data.py
+++ b/synthetic/get_data.py
@@ -94,10 +94,10 @@ class SyntheticDataset(Dataset):
     def __getitem__(self, index):
         tmp = []
         for i, modality in enumerate(self.modalities):
-            if modality:
-                tmp.append(torch.tensor(self.data[self.keys[i]][index]))
+            if self.keys[i] not in self.data.keys(): 
+                raise NotImplementedError
             else:
-                tmp.append(torch.ones(self.data[self.keys[i]][index].size))
+                tmp.append(torch.tensor(self.data[self.keys[i]][index]))
         tmp.append(torch.tensor(self.data[self.keys[-1]][index]))
         return tmp
 

--- a/unimodals/common_models.py
+++ b/unimodals/common_models.py
@@ -167,7 +167,7 @@ class MLP(torch.nn.Module):
             output = self.dropout_layer(output)
         output2 = self.fc2(output)
         if self.dropout:
-            output2 = self.dropout_layer(output)
+            output2 = self.dropout_layer(output2)
         if self.output_each_layer:
             return [0, x, output, self.lklu(output2)]
         return output2


### PR DESCRIPTION
## Uniqueness0 issue in synthetic dataset: 

It seems that when the synthetic data was retrieved through the __getitem__() method of SyntheticDataset(nn.Dataset) for uniqueness0 it was defaulting to a ones tensor that was written to handle missing keys in the data dictionary. However, even though '0' was a valid key, doing "if modality" when modality=0 in Python results in a False evaluation, which causes the uniqueness0 tensor to just be a ones tensor. This greatly affected downstream results for me, and I would recommend checking if this happens in the results reported into the actual paper by manually checking the contents of the first batch in the train dataloader. If this is the case, then I would highly recommend re-running all synthetic dataset experiments for this section. 

## MLP Dropout issue: 

the dropout wasn't being applied to the correct output tensor, i.e. the second dropout was being applied to the first tensor again, which resulted in no dropout for the actual output. This shouldn't affect results too much but I would re-run and see how it actually affects results where dropout is used for MLP. 

## Reproducibility Suggestion:
For other suggestions not found in this PR, I ensured result reproducibility by using pytorch-lightning's seed_everything function as follows: 
`
from pytorch_lightning import seed_everything
seed_everything(args.seed)
`
and backend settings for deterministic algos:
`
torch.backends.cudnn.deterministic = True
torch.backends.cudnn.benchmark = False
`
